### PR TITLE
Typo in README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For example, to get server uptime, call `get_uptime()` in the `common` module:
     $endpoint . '/apnscp.wsdl',
       array(
       'connection_timeout' => 5,
-      'location'           => $endpoint.'soap?authkey='.$key,
+      'location'           => $endpoint.'/soap?authkey='.$key,
       'uri'                => 'urn:net.apnscp.soap'
     )
   );


### PR DESCRIPTION
A missing slash in the 'location' param prevented the sample code from executing properly as is.
